### PR TITLE
Revert "Enable pushing into creedence/dotnet-packages-ref.hg."

### DIFF
--- a/mk/archive-push.sh
+++ b/mk/archive-push.sh
@@ -30,7 +30,7 @@
 
 set -eu
 
-#DISABLE_PUSH=1
+DISABLE_PUSH=1
 source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/declarations.sh"
 
 if [ ${XS_BRANCH} = "trunk" ]


### PR DESCRIPTION
This reverts commit 20131ebae0ce10245295816ac887559cb2033c75.
Unlike other branches creedence will follow the same integration schedule as trunk.
