### PR TITLE
Explicitly specify 2.0 as TargetFramework in MSBuild for making sure …

### DIFF
--- a/mk/dotnet-packages-build.sh
+++ b/mk/dotnet-packages-build.sh
@@ -128,6 +128,12 @@ run_msbuild()
   return $?
 }
 
+run_msbuild_dotnet2()
+{
+  MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v2.0 $*
+  return $?
+}
+
 run_msbuild_nofw()
 {
   MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /property:PlatformToolset=v120 $*
@@ -135,7 +141,7 @@ run_msbuild_nofw()
 }
 
 cd ${SCRATCH_DIR}/xml-rpc.net/src && run_msbuild
-cd ${SCRATCH_DIR}/xml-rpc_v2.net/src && run_msbuild && mv ../bin/CookComputing.XmlRpcV2.dll ../bin/CookComputing.XmlRpcV2_dotnet2.dll && mv ../bin/CookComputing.XmlRpcV2.pdb ../bin/CookComputing.XmlRpcV2_dotnet2.pdb #building for dotnet2
+cd ${SCRATCH_DIR}/xml-rpc_v2.net/src && run_msbuild_dotnet2 && mv ../bin/CookComputing.XmlRpcV2.dll ../bin/CookComputing.XmlRpcV2_dotnet2.dll && mv ../bin/CookComputing.XmlRpcV2.pdb ../bin/CookComputing.XmlRpcV2_dotnet2.pdb #building for dotnet2
 cd ${SCRATCH_DIR}/log4net/src     && run_msbuild log4net.vs2010.csproj
 cd ${SCRATCH_DIR}/sharpziplib/src && run_msbuild
 cd ${SCRATCH_DIR}/dotnetzip/DotNetZip-src/DotNetZip/Zip && run_msbuild


### PR DESCRIPTION
…we get .NET 2.0 targeted build when needed.

(It used to be working - for some reason, TargetFramework 4.0 was ignored by older MSBuilds). This is not the case with the new MSBuild 12)

Signed-off-by: Gabor Apati-Nagy <gabor.apati-nagy@citrix.com>