### PR TITLE
Update MSBuild.exe calls to use the correct one

### DIFF
--- a/mk/dotnet-packages-build.sh
+++ b/mk/dotnet-packages-build.sh
@@ -130,13 +130,13 @@ echo "INFO:	Performing main build tasks..."
 
 run_msbuild()
 {
-  MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.6 /property:PlatformToolset=v120 $*
+  C:/"Program Files (x86)"/MSBuild/14.0/bin/MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.6 /property:PlatformToolset=v140 /p:FrameworkPathOverride="C:/Program Files (x86)/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.6" $*
   return $?
 }
 
 run_msbuild_dotnet45()
 {
-  MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.5 /property:PlatformToolset=v120 $*
+  C:/"Program Files (x86)"/MSBuild/12.0/bin/MSBuild.exe /nologo /m /verbosity:minimal /p:Configuration=Release /p:TargetFrameworkVersion=v4.5 /property:PlatformToolset=v120 $*
   return $?
 }
 


### PR DESCRIPTION
14.0 for the 4.6 builds, and 12.0 for the 4.5 ones. Use FrameworkPathOverride for 4.6 call to use
the Reference Assemblies. (Note, this will merge on top of the reverted changes when we're ready)

Signed-off-by: Callum McIntyre <callumiandavid.mcintyre@citrix.com>