### PR TITLE
Stop archiving artifacts manually.

### DIFF
--- a/mk/archive-push.sh
+++ b/mk/archive-push.sh
@@ -32,9 +32,6 @@ set -eu
 
 source "$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/declarations.sh"
 
-#archive build artifacts manually
-cp -R ${OUTPUT_DIR}/* ${BUILD_ARCHIVE}
-
 # Secure build: update buildtools, copy output to local disk, then to remote.
 cd ${OUTPUT_DIR}
 if [ "${BUILD_KIND:+$BUILD_KIND}" = production ]

--- a/mk/declarations.sh
+++ b/mk/declarations.sh
@@ -113,7 +113,6 @@ then
    HUDSON_HOME=${HOME}
 fi
 
-BUILD_ARCHIVE=$(cygpath -u "${HUDSON_HOME}")/jobs/${get_JOB_NAME}/builds/${get_BUILD_ID}/archive
 SECURE_BUILD_ARCHIVE_UNC=//10.80.13.10/distfiles/distfiles/WindowsBuilds/
 SNK_ORIG=$(cygpath -w "${HOME}/.ssh/xs.net.snk")
 SNK=${SNK_ORIG//\\/\\\\}

--- a/mk/dotnet-packages-build.sh
+++ b/mk/dotnet-packages-build.sh
@@ -40,7 +40,6 @@ mkdir_clean()
 mkdir_clean ${SCRATCH_DIR}
 mkdir_clean ${OUTPUT_DIR}
 mkdir_clean ${OUTPUT_SRC_DIR}
-mkdir_clean ${BUILD_ARCHIVE}
 
 if [ "${BUILD_KIND:+$BUILD_KIND}" = production ]
 then


### PR DESCRIPTION
It seems at some point archiving was enabled on jenkins without noticing the build script was doing this already. I'm removing it from the script.